### PR TITLE
Enterキーに「進む」を割り当てる

### DIFF
--- a/src/useInput.ts
+++ b/src/useInput.ts
@@ -12,7 +12,7 @@ export const useInput = (scene: Phaser.Scene): UseInput => {
     useHandCursor: true,
   });
   const space = scene.input.keyboard.addKey(
-    Phaser.Input.Keyboard.KeyCodes.SPACE
+    Phaser.Input.Keyboard.KeyCodes.ENTER
   );
 
   const setEventHandler = (handler: Function): void => {


### PR DESCRIPTION
ティラノに合わせてEnterキーに「進む」を割り当てました。

いつのまにかSpaceキーに割り当ててしまってました。